### PR TITLE
form data 테스트용 유틸리티 만들기

### DIFF
--- a/src/test/java/com/fastcampus/projectboard/util/FormDataEncoder.java
+++ b/src/test/java/com/fastcampus/projectboard/util/FormDataEncoder.java
@@ -1,0 +1,34 @@
+package com.fastcampus.projectboard.util;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Map;
+
+@TestComponent
+public class FormDataEncoder {
+
+    private final ObjectMapper mapper;
+
+    public FormDataEncoder(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+
+    public String encode(Object obj) {
+        Map<String, String> fieldMap = mapper.convertValue(obj, new TypeReference<>() {});
+        MultiValueMap<String, String> valueMap = new LinkedMultiValueMap<>();
+        valueMap.setAll(fieldMap);
+
+        return UriComponentsBuilder.newInstance()
+                .queryParams(valueMap)
+                .encode()
+                .build()
+                .getQuery();
+    }
+
+}

--- a/src/test/java/com/fastcampus/projectboard/util/FormDataEncoderTest.java
+++ b/src/test/java/com/fastcampus/projectboard/util/FormDataEncoderTest.java
@@ -1,0 +1,75 @@
+package com.fastcampus.projectboard.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("테스트 도구 - Form 데이터 인코더")
+@Import({FormDataEncoder.class, ObjectMapper.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = Void.class)
+class FormDataEncoderTest {
+
+    private final FormDataEncoder formDataEncoder;
+
+    public FormDataEncoderTest(@Autowired FormDataEncoder formDataEncoder) {
+        this.formDataEncoder = formDataEncoder;
+    }
+
+    @DisplayName("객체를 넣으면, url encoding 된 form body data 형식의 문자열을 돌려준다.")
+    @Test
+    void givenObject_whenEncoding_thenReturnsFormEncodedString() {
+        // Given
+        TestObject obj = new TestObject(
+                "This 'is' \"test\" string.",
+                List.of("hello", "my", "friend").toString().replace(" ", ""),
+                String.join(",", "hello", "my", "friend"),
+                null,
+                1234,
+                3.14,
+                false,
+                BigDecimal.TEN,
+                TestEnum.THREE
+        );
+
+        // When
+        String result = formDataEncoder.encode(obj);
+
+        // Then
+        assertThat(result).isEqualTo(
+                "str=This%20'is'%20%22test%22%20string." +
+                        "&listStr1=%5Bhello,my,friend%5D" +
+                        "&listStr2=hello,my,friend" +
+                        "&nullStr" +
+                        "&number=1234" +
+                        "&floatingNumber=3.14" +
+                        "&bool=false" +
+                        "&bigDecimal=10" +
+                        "&testEnum=THREE"
+        );
+    }
+
+    record TestObject(
+            String str,
+            String listStr1,
+            String listStr2,
+            String nullStr,
+            Integer number,
+            Double floatingNumber,
+            Boolean bool,
+            BigDecimal bigDecimal,
+            TestEnum testEnum
+    ) {}
+
+    enum TestEnum {
+        ONE, TWO, THREE
+    }
+
+}


### PR DESCRIPTION
이 작업은 게시글 입력 테스트를 대비하여 쉽게 form data를 재현할 수 있는 테스트 전용 유틸리티를 구현합니다.

This closes #33 