### PR TITLE
회원 정보: 잘못된 도메인 정보 바로잡기

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/fastcampus/projectboard/domain/UserAccount.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 @Getter
 @ToString
 @Table(indexes = {
-        @Index(columnList = "userId"),
+        @Index(columnList = "userId", unique = true),
         @Index(columnList = "email", unique = true),
         @Index(columnList = "createdAt"),
         @Index(columnList = "createdBy")

--- a/src/test/java/com/fastcampus/projectboard/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fastcampus/projectboard/repository/JpaRepositoryTest.java
@@ -85,7 +85,7 @@ class JpaRepositoryTest {
         void givenTestData_whenInserting_thenWorksFine() {
             // Given
             long previousCount = articleRepository.count();
-            UserAccount userAccount = userAccountRepository.save(UserAccount.of("uno", "pw", null, null, null));
+            UserAccount userAccount = userAccountRepository.save(UserAccount.of("uno-new", "pw", null, null, null));
             Article article = Article.of(userAccount, "new article", "new content", "#spring");
 
             // When


### PR DESCRIPTION
이 작업은 회원 엔티티의 `userId`에 유니크 키를 추가합니다.
`userId`는 실제 고객의 계정 ID이므로, 중복이 있을 수 없는데 이게 설계에 안 들어갔습니다. 이를 보완합니다.

This closes #23 