### PR TITLE
DTO 리팩토링: 메타정보를 필요로 하지 않는 생성자 추가

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/dto/ArticleCommentDto.java
+++ b/src/main/java/com/fastcampus/projectboard/dto/ArticleCommentDto.java
@@ -15,6 +15,11 @@ public record ArticleCommentDto(
         LocalDateTime modifiedAt,
         String modifiedBy
 ) {
+
+    public static ArticleCommentDto of(Long articleId, UserAccountDto userAccountDto, String content) {
+        return new ArticleCommentDto(null, articleId, userAccountDto, content, null, null, null, null);
+    }
+
     public static ArticleCommentDto of(Long id, Long articleId, UserAccountDto userAccountDto, String content, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
         return new ArticleCommentDto(id, articleId, userAccountDto, content, createdAt, createdBy, modifiedAt, modifiedBy);
     }

--- a/src/main/java/com/fastcampus/projectboard/dto/ArticleDto.java
+++ b/src/main/java/com/fastcampus/projectboard/dto/ArticleDto.java
@@ -15,6 +15,11 @@ public record ArticleDto(
         LocalDateTime modifiedAt,
         String modifiedBy
 ) {
+
+    public static ArticleDto of(UserAccountDto userAccountDto, String title, String content, String hashtag) {
+        return new ArticleDto(null, userAccountDto, title, content, hashtag, null, null, null, null);
+    }
+
     public static ArticleDto of(Long id, UserAccountDto userAccountDto, String title, String content, String hashtag, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
         return new ArticleDto(id, userAccountDto, title, content, hashtag, createdAt, createdBy, modifiedAt, modifiedBy);
     }

--- a/src/main/java/com/fastcampus/projectboard/dto/ArticleWithCommentsDto.java
+++ b/src/main/java/com/fastcampus/projectboard/dto/ArticleWithCommentsDto.java
@@ -19,6 +19,11 @@ public record ArticleWithCommentsDto(
         LocalDateTime modifiedAt,
         String modifiedBy
 ) {
+
+    public static ArticleWithCommentsDto of(UserAccountDto userAccountDto, Set<ArticleCommentDto> articleCommentDtos, String title, String content, String hashtag) {
+        return new ArticleWithCommentsDto(null, userAccountDto, articleCommentDtos, title, content, hashtag, null, null, null, null);
+    }
+
     public static ArticleWithCommentsDto of(Long id, UserAccountDto userAccountDto, Set<ArticleCommentDto> articleCommentDtos, String title, String content, String hashtag, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
         return new ArticleWithCommentsDto(id, userAccountDto, articleCommentDtos, title, content, hashtag, createdAt, createdBy, modifiedAt, modifiedBy);
     }

--- a/src/main/java/com/fastcampus/projectboard/dto/UserAccountDto.java
+++ b/src/main/java/com/fastcampus/projectboard/dto/UserAccountDto.java
@@ -16,6 +16,11 @@ public record UserAccountDto(
         LocalDateTime modifiedAt,
         String modifiedBy
 ) {
+
+    public static UserAccountDto of(String userId, String userPassword, String email, String nickname, String memo) {
+        return new UserAccountDto(null, userId, userPassword, email, nickname, memo, null, null, null, null);
+    }
+
     public static UserAccountDto of(Long id, String userId, String userPassword, String email, String nickname, String memo, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
         return new UserAccountDto(id, userId, userPassword, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
     }

--- a/src/test/java/com/fastcampus/projectboard/service/PaginationServiceTest.java
+++ b/src/test/java/com/fastcampus/projectboard/service/PaginationServiceTest.java
@@ -14,7 +14,7 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-@DisplayName("비즈니스 로직 - 페이지네이션")
+@DisplayName("[Service] 페이지네이션 서비스 테스트")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = PaginationService.class)
 class PaginationServiceTest {
 

--- a/src/test/java/com/fastcampus/projectboard/util/FormDataEncoderTest.java
+++ b/src/test/java/com/fastcampus/projectboard/util/FormDataEncoderTest.java
@@ -5,16 +5,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
 
 import java.math.BigDecimal;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@DisplayName("테스트 도구 - Form 데이터 인코더")
-@Import({FormDataEncoder.class, ObjectMapper.class})
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = Void.class)
+@DisplayName("[Util][Test] Form 데이터 인코더 테스트")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = {FormDataEncoder.class, ObjectMapper.class})
 class FormDataEncoderTest {
 
     private final FormDataEncoder formDataEncoder;


### PR DESCRIPTION
이 작업은 기존 기본 dto들에 메타 정보를 입력할 필요 없는 생성자를 추가합니다.

This closes #32 